### PR TITLE
Support other non-error HTTP response codes without throwing an Exception

### DIFF
--- a/classes/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
+++ b/classes/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
@@ -156,10 +156,7 @@ public class NettyHttpClient implements HttpClient, WsClient {
             NettyHttpClientHandler handler = (NettyHttpClientHandler) ch.pipeline().get("http-handler");
             ch.writeAndFlush(request);
             ch.closeFuture().sync();
-            if (HttpResponseStatus.OK.equals(handler.getResponseStatus())
-                || HttpResponseStatus.NO_CONTENT.equals(handler.getResponseStatus())
-                || HttpResponseStatus.ACCEPTED.equals(handler.getResponseStatus())
-                || HttpResponseStatus.CREATED.equals(handler.getResponseStatus())) {
+            if (isSuccess(handler.getResponseStatus())) {
                 return handler.getResponseText();
             } else {
                 throw makeException(handler.getResponseStatus(), handler.getResponseText(), errors);
@@ -192,10 +189,7 @@ public class NettyHttpClient implements HttpClient, WsClient {
                             responseHandler.onDisconnect();
                             if (future.isSuccess()) {
                                 NettyHttpClientHandler handler = (NettyHttpClientHandler) future.channel().pipeline().get("http-handler");
-                                if (HttpResponseStatus.OK.equals(handler.getResponseStatus())
-                                    || HttpResponseStatus.NO_CONTENT.equals(handler.getResponseStatus())
-                                    || HttpResponseStatus.ACCEPTED.equals(handler.getResponseStatus())
-                                    || HttpResponseStatus.CREATED.equals(handler.getResponseStatus())) {
+                                if (isSuccess(handler.getResponseStatus())) {
                                     responseHandler.onSuccess(handler.getResponseText());
                                 } else {
                                     responseHandler.onFailure(makeException(handler.getResponseStatus(), handler.getResponseText(), errors));
@@ -262,5 +256,17 @@ public class NettyHttpClient implements HttpClient, WsClient {
                 }
             }
         };
+    }
+
+    private boolean isSuccess(HttpResponseStatus status) {
+
+        if (HttpResponseStatus.OK.equals(status)
+            || HttpResponseStatus.NO_CONTENT.equals(status)
+            || HttpResponseStatus.ACCEPTED.equals(status)
+            || HttpResponseStatus.CREATED.equals(status))
+        {
+            return true;
+        }
+        return false;
     }
 }

--- a/classes/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
+++ b/classes/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
@@ -156,7 +156,10 @@ public class NettyHttpClient implements HttpClient, WsClient {
             NettyHttpClientHandler handler = (NettyHttpClientHandler) ch.pipeline().get("http-handler");
             ch.writeAndFlush(request);
             ch.closeFuture().sync();
-            if (HttpResponseStatus.OK.equals(handler.getResponseStatus()) || HttpResponseStatus.NO_CONTENT.equals(handler.getResponseStatus())) {
+            if (HttpResponseStatus.OK.equals(handler.getResponseStatus())
+                || HttpResponseStatus.NO_CONTENT.equals(handler.getResponseStatus())
+                || HttpResponseStatus.ACCEPTED.equals(handler.getResponseStatus())
+                || HttpResponseStatus.CREATED.equals(handler.getResponseStatus())) {
                 return handler.getResponseText();
             } else {
                 throw makeException(handler.getResponseStatus(), handler.getResponseText(), errors);
@@ -189,7 +192,10 @@ public class NettyHttpClient implements HttpClient, WsClient {
                             responseHandler.onDisconnect();
                             if (future.isSuccess()) {
                                 NettyHttpClientHandler handler = (NettyHttpClientHandler) future.channel().pipeline().get("http-handler");
-                                if (HttpResponseStatus.OK.equals(handler.getResponseStatus()) || HttpResponseStatus.NO_CONTENT.equals(handler.getResponseStatus())) {
+                                if (HttpResponseStatus.OK.equals(handler.getResponseStatus())
+                                    || HttpResponseStatus.NO_CONTENT.equals(handler.getResponseStatus())
+                                    || HttpResponseStatus.ACCEPTED.equals(handler.getResponseStatus())
+                                    || HttpResponseStatus.CREATED.equals(handler.getResponseStatus())) {
                                     responseHandler.onSuccess(handler.getResponseText());
                                 } else {
                                     responseHandler.onFailure(makeException(handler.getResponseStatus(), handler.getResponseText(), errors));


### PR DESCRIPTION
Fixes #33 

I thought it would make sense to support ACCEPTED as well, in case that is used in the future.  An alternate option would be to check that the status code is >= 200 && < 300, since those are arguably all successes, but codes like "206 Partial Content" are likely to imply some significant change in behavior on the server side, so it might be best to explicitly whitelist the ones we think are likely and valid.