### PR TITLE
Update NettyWSClientHandler.java

### DIFF
--- a/classes/ch/loway/oss/ari4java/tools/http/NettyWSClientHandler.java
+++ b/classes/ch/loway/oss/ari4java/tools/http/NettyWSClientHandler.java
@@ -1,6 +1,7 @@
 package ch.loway.oss.ari4java.tools.http;
 
 import ch.loway.oss.ari4java.tools.HttpResponseHandler;
+import ch.loway.oss.ari4java.tools.RestException;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
@@ -77,8 +78,8 @@ public class NettyWSClientHandler extends NettyHttpClientHandler {
         } else if (frame instanceof PongWebSocketFrame) {
             System.out.println("WebSocket Client received pong");
         } else if (frame instanceof CloseWebSocketFrame) {
-            System.out.println("WebSocket Client received closing");
             ch.close();
+            wsCallback.onFailure(new RestException("WebSocket Client received close"));
         }
         
     }


### PR DESCRIPTION
I upgraded my Asterisk to 13.7.2 recently (not sure what version I was on) and I stopped receiving events after a while. I saw the following message `WebSocket Client received closing` on the console and no new events post that. This pull request is to raise an error using the `onFailure` callback so that my application can reconnect.
Some background info I found:
The [ASTERISK-24701](https://issues.asterisk.org/jira/browse/ASTERISK-24701) issue was resolved, which highlights disconnecting the socket when a write timeout occurs. The default timeout is 100 milliseconds which is very short especially when receiving a bunch of events... This can be edited now using the `websocket_write_timeout` setting in the `ari.conf` file.
I set mine to `websocket_write_timeout=5000` so that block of code is not reached, but for safety and completeness an error would be better than nothing ;-)