### PR TITLE
added onDisconnect and applied when websoket disconnects

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you use Gradle (or any tool using Maven dependencies) you can simply declare 
 
 
 	dependencies {
-	    compile 'ch.loway.oss.ari4java:ari4java:0.3.4'
+	    compile 'ch.loway.oss.ari4java:ari4java:0.3.5'
 	}
 
 This will download the package and all required dependencies.

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ def env = System.getenv()
 
 project.ext {
   webapp_name    = 'ari4java'
-  app_version    = '0.3.4'
+  app_version    = '0.3.5'
   build_number   = env["BUILD_NUMBER"]  
   version_class  = 'ch/loway/oss/ari4java/BUILD.java'
   build_time     = "" + new Date()

--- a/classes/ch/loway/oss/ari4java/tools/AriAsyncHandler.java
+++ b/classes/ch/loway/oss/ari4java/tools/AriAsyncHandler.java
@@ -50,7 +50,13 @@ public class AriAsyncHandler<T> implements HttpResponseHandler {
 
     @Override
     public void onResponseReceived() {
-        //this.callback.onFailure(new RestException("Asterisk WS is disconnected. Please retry."));
+        // not sure what should go here...
+    }
+
+    @Override
+    public void onDisconnect() {
+        // this is from channelInactive on the websocket raise an error so the client can reconnect if need be
+        this.callback.onFailure(new RestException("Asterisk WS is disconnected. Please retry."));
     }
 
     @Override

--- a/classes/ch/loway/oss/ari4java/tools/HttpResponseHandler.java
+++ b/classes/ch/loway/oss/ari4java/tools/HttpResponseHandler.java
@@ -18,6 +18,11 @@ public interface HttpResponseHandler {
     void onResponseReceived();
 
     /**
+     * WebSocket disconnected
+     */
+    void onDisconnect();
+
+    /**
      * All went well.
      *
      * @param response

--- a/classes/ch/loway/oss/ari4java/tools/http/NettyWSClientHandler.java
+++ b/classes/ch/loway/oss/ari4java/tools/http/NettyWSClientHandler.java
@@ -50,7 +50,7 @@ public class NettyWSClientHandler extends NettyHttpClientHandler {
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        wsCallback.onResponseReceived();
+        wsCallback.onDisconnect();
     }
 
     @Override


### PR DESCRIPTION
Hi @l3nz 

A while back you added a RestException when the websocket is disconnected - [Issue #26](https://github.com/l3nz/ari4java/issues/26)
So the code added was commented out with some refactoring...
`ari4java/classes/ch/loway/oss/ari4java/tools/AriAsyncHandler.java`
```
    @Override
    public void onResponseReceived() {
        //this.callback.onFailure(new RestException("Asterisk WS is disconnected. Please retry."));
    }
```
I've added another method to the `HttpResponseHandler` - `onDisconnect` to avoid confusion
I've sent a pull request - if you wouldn't mind checking if I've not missed anything and merging, I need to deploy this soon - thanks