### PR TITLE
implement auto reconnect and websocket ping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ def env = System.getenv()
 
 project.ext {
   webapp_name    = 'ari4java'
-  app_version    = '0.4.0'
+  app_version    = '0.5.0'
   build_number   = env["BUILD_NUMBER"]  
   version_class  = 'ch/loway/oss/ari4java/BUILD.java'
   build_time     = "" + new Date()

--- a/classes/ch/loway/oss/ari4java/ARI.java
+++ b/classes/ch/loway/oss/ari4java/ARI.java
@@ -363,11 +363,18 @@ public class ARI {
     public void cleanup() throws ARIException {
 
         if ( liveActionEvent != null ) {
-            closeAction( liveActionEvent );
+            try {
+                closeAction(liveActionEvent);
+            } catch (ARIException e) {
+                // ignore on cleanup...
+            }
+            liveActionEvent = null;
         }
 
         destroy( wsClient );
-        destroy( httpClient );
+        if (wsClient != httpClient) {
+            destroy(httpClient);
+        }
 
         wsClient = null;
         httpClient = null;

--- a/classes/ch/loway/oss/ari4java/tools/AriAsyncHandler.java
+++ b/classes/ch/loway/oss/ari4java/tools/AriAsyncHandler.java
@@ -12,6 +12,7 @@ public class AriAsyncHandler<T> implements HttpResponseHandler {
     private final AriCallback<? super T> callback;
     private Class<T> klazz;
     private TypeReference<T> klazzType;
+    private long lastResponseTime = 0;
 
     public AriAsyncHandler(AriCallback<? super T> callback, Class<T> klazz) {
         this.callback = callback;
@@ -45,12 +46,12 @@ public class AriAsyncHandler<T> implements HttpResponseHandler {
 
     @Override
     public void onChReadyToWrite() {
-        // Client connected. That's good.
+        lastResponseTime = System.currentTimeMillis();
     }
 
     @Override
     public void onResponseReceived() {
-        // not sure what should go here...
+        lastResponseTime = System.currentTimeMillis();
     }
 
     @Override
@@ -67,6 +68,11 @@ public class AriAsyncHandler<T> implements HttpResponseHandler {
     @Override
     public void onFailure(Throwable e) {
         this.callback.onFailure(new RestException(e));
+    }
+
+    @Override
+    public long getLastResponseTime() {
+        return lastResponseTime;
     }
 
 }

--- a/classes/ch/loway/oss/ari4java/tools/BaseAriAction.java
+++ b/classes/ch/loway/oss/ari4java/tools/BaseAriAction.java
@@ -203,10 +203,6 @@ public class BaseAriAction {
      * @throws RestException
      */
     public synchronized void disconnectWs() throws RestException {
-        System.out.println("Closing WS connection");
-        if (wsUpgrade && wsConnection == null) {
-            throw new RestException("No WebSocket connection is open");
-        }
         wsConnection.disconnect();
         wsConnection = null;
     }

--- a/classes/ch/loway/oss/ari4java/tools/HttpResponseHandler.java
+++ b/classes/ch/loway/oss/ari4java/tools/HttpResponseHandler.java
@@ -35,4 +35,11 @@ public interface HttpResponseHandler {
      * @param e
      */
     void onFailure(Throwable e);
+
+    /**
+     * The last time in epoch since last response
+     *
+     * @return epoch
+     */
+    long getLastResponseTime();
 }

--- a/classes/ch/loway/oss/ari4java/tools/WsClientAutoReconnect.java
+++ b/classes/ch/loway/oss/ari4java/tools/WsClientAutoReconnect.java
@@ -1,0 +1,11 @@
+package ch.loway.oss.ari4java.tools;
+
+/**
+ * Interface to pluggable WebSocket reconnect implementation
+ * 
+ * @author grahambrown11
+ *
+ */
+public interface WsClientAutoReconnect {
+	void reconnectWs();
+}

--- a/classes/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
+++ b/classes/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
@@ -1,44 +1,29 @@
 package ch.loway.oss.ari4java.tools.http;
 
+import ch.loway.oss.ari4java.tools.*;
+import ch.loway.oss.ari4java.tools.HttpResponse;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelHandler.Sharable;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.*;
-import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
-import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
-import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
-import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
-import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
-import io.netty.handler.codec.http.websocketx.WebSocketFrame;
-import io.netty.handler.codec.http.websocketx.WebSocketVersion;
-import io.netty.util.CharsetUtil;
+import io.netty.handler.codec.http.websocketx.*;
+import io.netty.util.concurrent.ScheduledFuture;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
-
-import ch.loway.oss.ari4java.tools.HttpParam;
-import ch.loway.oss.ari4java.tools.HttpResponse;
-import ch.loway.oss.ari4java.tools.HttpClient;
-import ch.loway.oss.ari4java.tools.HttpResponseHandler;
-import ch.loway.oss.ari4java.tools.RestException;
-import ch.loway.oss.ari4java.tools.WsClient;
+import java.util.concurrent.TimeUnit;
 
 /**
  * HTTP and WebSocket client implementation based on netty.io.
@@ -51,20 +36,34 @@ import ch.loway.oss.ari4java.tools.WsClient;
  * @author mwalton
  *
  */
-public class NettyHttpClient implements HttpClient, WsClient {
+public class NettyHttpClient implements HttpClient, WsClient, WsClientAutoReconnect {
 
     public static final int MAX_HTTP_REQUEST_KB = 256;
     
     private Bootstrap bootStrap;
     private URI baseUri;
     private EventLoopGroup group;
+    private EventLoopGroup shutDownGroup;
     private String username;
     private String password;
+
+    private HttpResponseHandler wsCallback;
+    private String wsEventsUrl;
+    private List<HttpParam> wsEventsParamQuery;
+    private WsClientConnection wsClientConnection;
+    private int reconnectCount = 0;
+    private ChannelFuture wsChannelFuture;
+    private ScheduledFuture<?> wsPingTimer = null;
+    private NettyWSClientHandler wsHandler;
+
+    public NettyHttpClient() {
+        group = new NioEventLoopGroup();
+        shutDownGroup = new NioEventLoopGroup();
+    }
 
     public void initialize(String baseUrl, String username, String password) throws URISyntaxException {
         this.username = username;
         this.password = password;
-        group = new NioEventLoopGroup();
         baseUri = new URI(baseUrl);
         String protocol = baseUri.getScheme();
         if (!"http".equals(protocol)) {
@@ -80,16 +79,30 @@ public class NettyHttpClient implements HttpClient, WsClient {
             public void initChannel(SocketChannel ch) throws Exception {
                 ChannelPipeline pipeline = ch.pipeline();
                 pipeline.addLast("http-codec", new HttpClientCodec());
-                pipeline.addLast("aggregator", new HttpObjectAggregator( MAX_HTTP_REQUEST_KB *1024));
+                pipeline.addLast("aggregator", new HttpObjectAggregator( MAX_HTTP_REQUEST_KB * 1024));
                 pipeline.addLast("http-handler", new NettyHttpClientHandler());
             }
         });
     }
 
     public void destroy() {
-        if (group != null) {
-            group.shutdownGracefully();
-        }
+        // use a different event group to execute the shutdown to avoid deadlocks
+        shutDownGroup.schedule(new Runnable() {
+            @Override
+            public void run() {
+                if (wsClientConnection != null) {
+                    try {
+                        wsClientConnection.disconnect();
+                    } catch (RestException e) {
+                        // not bubbling exception up, just ignoring
+                    }
+                }
+                if (group != null && !group.isShuttingDown()) {
+                    group.shutdownGracefully(5, 10, TimeUnit.SECONDS).syncUninterruptibly();
+                    group = null;
+                }
+            }
+        }, 250L, TimeUnit.MILLISECONDS);
     }
 
     // Factory for WS handshakes
@@ -231,6 +244,12 @@ public class NettyHttpClient implements HttpClient, WsClient {
 
     @Override
     public WsClientConnection connect(final HttpResponseHandler callback, final String url, final List<HttpParam> lParamQuery) throws RestException {
+
+        this.wsCallback = callback;
+        this.wsEventsUrl = url;
+        this.wsEventsParamQuery = lParamQuery;
+        this.wsHandler = new NettyWSClientHandler(getWsHandshake(url, lParamQuery), callback, this);
+
         Bootstrap wsBootStrap = new Bootstrap();
         wsBootStrap.group(group);
         wsBootStrap.channel(NioSocketChannel.class);
@@ -241,45 +260,68 @@ public class NettyHttpClient implements HttpClient, WsClient {
                 ChannelPipeline pipeline = ch.pipeline();
                 pipeline.addLast("http-codec", new HttpClientCodec());
                 pipeline.addLast("aggregator", new HttpObjectAggregator(MAX_HTTP_REQUEST_KB * 1024));
-                pipeline.addLast("ws-handler", new NettyWSClientHandler(getWsHandshake(url, lParamQuery), callback));
+                pipeline.addLast("ws-handler", wsHandler);
             }
         });
-        final ChannelFuture cf = wsBootStrap.connect(baseUri.getHost(), baseUri.getPort());
-        cf.addListener(new ChannelFutureListener() {
+        wsChannelFuture = wsBootStrap.connect(baseUri.getHost(), baseUri.getPort());
+        wsChannelFuture.addListener(new ChannelFutureListener() {
 
             @Override
             public void operationComplete(ChannelFuture future) throws Exception {
                 if (future.isSuccess()) {
                     callback.onChReadyToWrite();
-                    // Nothing - handshake future will activate later
-					/*Channel ch = future.channel();
-                    NettyWSClientHandler handler = (NettyWSClientHandler) ch.pipeline().get("ws-handler");
-                    handler.handshakeFuture.sync();*/
+					// reset the reconnect counter on successful connect
+                    reconnectCount = 0;
                 } else {
-                    callback.onFailure(future.cause());
+                    if (reconnectCount >= 10)
+                        callback.onFailure(future.cause());
+                    else
+                        reconnectWs();
                 }
             }
         });
-        // Provide disconnection handle to client
-        return new WsClientConnection() {
 
-            @Override
-            public void disconnect() throws RestException {
-                Channel ch = cf.channel();
-                if (ch != null) {
-                    ch.writeAndFlush(new CloseWebSocketFrame());
-                    // NettyWSClientHandler will close the connection when the server
-                    // responds to the CloseWebSocketFrame.
-                    try {
-                        ch.closeFuture().sync();
-                    } catch (InterruptedException e) {
-                        throw new RestException(e);
-                    }
-                }
-            }
-        };
+        // start a ws ping schedule
+        startPing();
+
+        // Provide disconnection handle to client
+        return createWsClientConnection();
     }
 
+    private void startPing() {
+        if (wsPingTimer == null) {
+            wsPingTimer = group.scheduleAtFixedRate(new Runnable() {
+                @Override
+                public void run() {
+                    if (System.currentTimeMillis() - wsCallback.getLastResponseTime() > 15000) {
+                        if (!wsChannelFuture.isCancelled() && wsChannelFuture.channel() != null) {
+                            WebSocketFrame frame = new PingWebSocketFrame(Unpooled.wrappedBuffer("ari4j".getBytes()));
+                            wsChannelFuture.channel().writeAndFlush(frame);
+                        }
+                    }
+                }
+            }, 5, 5, TimeUnit.MINUTES);
+        }
+    }
+
+    private WsClientConnection createWsClientConnection() {
+        if (this.wsClientConnection == null) {
+            this.wsClientConnection = new WsClientConnection() {
+
+                @Override
+                public void disconnect() throws RestException {
+                    wsHandler.setShuttingDown(true);
+                    Channel ch = wsChannelFuture.channel();
+                    if (ch != null) {
+                        ch.writeAndFlush(new CloseWebSocketFrame());
+                        // NettyWSClientHandler will close the connection when the server
+                        // responds to the CloseWebSocketFrame.
+                    }
+                }
+            };
+        }
+        return this.wsClientConnection;
+    }
     
     /**
      * Checks if a response is okay.
@@ -300,6 +342,31 @@ public class NettyHttpClient implements HttpClient, WsClient {
         }
 
     }
-    
-    
+
+
+    @Override
+    public void reconnectWs() {
+        // cancel the ping timer
+        if (wsPingTimer != null) {
+            wsPingTimer.cancel(false);
+            wsPingTimer = null;
+        }
+        // if not shutdown reconnect, note the check not on the shutDownGroup
+        if (!group.isShuttingDown()) {
+            // schedule reconnect after a 1,5,10 seconds
+            long[] timeouts = {1L, 5L, 10L};
+            shutDownGroup.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    reconnectCount++;
+                    try {
+                        System.err.println(System.currentTimeMillis() + " ** connecting...  try:" + reconnectCount + " ++");
+                        connect(wsCallback, wsEventsUrl, wsEventsParamQuery);
+                    } catch (RestException e) {
+                        wsCallback.onFailure(e);
+                    }
+                }
+            }, reconnectCount >= timeouts.length ? timeouts[timeouts.length - 1] : timeouts[reconnectCount], TimeUnit.SECONDS);
+        }
+    }
 }


### PR DESCRIPTION
Implemented the auto reconnect - this is to address issue #46 
The magic works as follows:
Will attempt 10 reconnects, the 1st waits a sec, the second 5 secs and thereafter 10 secs. If the 10th connection is unsuccessful the onFailure callback is called, so the main application will receive an error almost a minute later if ARI4J was unable to re-establish the connection.

I also added a ping schedule to send the WS ping frame every 5 minutes, will skip the ping if there's been an event in the last 15 seconds

This is to address issue #46 
