### PR TITLE
Code Generator: replaced HashMap by LinkedHashMap to keep order of generated code

### DIFF
--- a/codegen/ch/loway/oss/ari4java/codegen/DefMapper.java
+++ b/codegen/ch/loway/oss/ari4java/codegen/DefMapper.java
@@ -1,6 +1,8 @@
 
 package ch.loway.oss.ari4java.codegen;
 
+import static ch.loway.oss.ari4java.codegen.run.CLASSES;
+
 import ch.loway.oss.ari4java.codegen.genJava.JavaGen;
 import ch.loway.oss.ari4java.codegen.genJava.JavaInterface;
 import ch.loway.oss.ari4java.codegen.genJava.JavaPkgInfo;
@@ -8,9 +10,9 @@ import ch.loway.oss.ari4java.codegen.models.Action;
 import ch.loway.oss.ari4java.codegen.models.Apis;
 import ch.loway.oss.ari4java.codegen.models.AriBuilderInterface;
 import ch.loway.oss.ari4java.codegen.models.ClassTranslator;
-import ch.loway.oss.ari4java.codegen.models.Operation;
 import ch.loway.oss.ari4java.codegen.models.Model;
 import ch.loway.oss.ari4java.codegen.models.ModelField;
+import ch.loway.oss.ari4java.codegen.models.Operation;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -22,9 +24,9 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +44,7 @@ public class DefMapper {
 
     List<Apis> myAPIs = new ArrayList<Apis>();
 
-    Map<String, JavaInterface> interfaces = new HashMap<String, JavaInterface>();
+    Map<String, JavaInterface> interfaces = new LinkedHashMap<>();
     String myAbsoluteProjectFolder = ".";
     
     
@@ -168,7 +170,7 @@ public class DefMapper {
         }
 
         // generate the AriBuilder class
-        saveToDisk( "classes/", "ch.loway.oss.ari4java.generated", "AriBuilder", abi.toString() );
+        saveToDisk(CLASSES, "ch.loway.oss.ari4java.generated", "AriBuilder", abi.toString() );
         return abi;
     }
 
@@ -213,8 +215,8 @@ public class DefMapper {
 
     public void generateProperties( AriBuilderInterface abi ) throws IOException {
 
-        Map<String,Set<Model>> mM = new HashMap<String, Set<Model>>();
-        Map<String,Set<Apis>> mA = new HashMap<String, Set<Apis>>();
+        Map<String,Set<Model>> mM = new LinkedHashMap<>();
+        Map<String,Set<Apis>> mA = new LinkedHashMap<>();
 
         for ( Apis api: myAPIs ) {
             String ver = api.apiVersion;
@@ -250,7 +252,7 @@ public class DefMapper {
     
     public void generateImplementationClasses( AriBuilderInterface abi ) throws IOException {
 
-        Map<String,ClassTranslator> mTranslators = new HashMap<String,ClassTranslator>();
+        Map<String,ClassTranslator> mTranslators = new LinkedHashMap<>();
         
        for ( Apis api: myAPIs ) {
             String ver = api.apiVersion;
@@ -423,24 +425,24 @@ public class DefMapper {
     }
 
     public void saveToDisk( Model model ) throws IOException {
-        saveToDisk( "classes/", model.getModelPackage(), model.getImplName(), model.toString() );
+        saveToDisk(CLASSES, model.getModelPackage(), model.getImplName(), model.toString() );
     }
 
     public void saveToDisk( Apis api ) throws IOException {
-        saveToDisk( "classes/", api.getActionsPackage(), api.getImplName(), api.toString() );
+        saveToDisk(CLASSES, api.getActionsPackage(), api.getImplName(), api.toString() );
     }
 
     public void saveToDisk( JavaInterface ji ) throws IOException {
-        saveToDisk( "classes/", "ch.loway.oss.ari4java.generated", ji.className, ji.toString() );
+        saveToDisk(CLASSES, "ch.loway.oss.ari4java.generated", ji.className, ji.toString() );
     }
 
     public void saveToDisk( ClassTranslator ct ) throws IOException {
-        saveToDisk( "classes/", ct.getBaseApiPackage(), ct.getImplName(), ct.toString() );
+        saveToDisk(CLASSES, ct.getBaseApiPackage(), ct.getImplName(), ct.toString() );
     }
 
     
     public void clean(String apiVersion) throws IOException {
-    	String base = "classes/ch/loway/oss/ari4java/generated";
+    	String base = CLASSES +"ch/loway/oss/ari4java/generated";
     	cleanPath(base+"/"+apiVersion+"/actions");
     	cleanPath(base+"/"+apiVersion+"/models");
     }
@@ -584,7 +586,7 @@ public class DefMapper {
         
         sb.append( "};");
 
-        saveToDisk( "classes/", "ch.loway.oss.ari4java.generated." + apiVersion, thisClass, sb.toString() );
+        saveToDisk(CLASSES, "ch.loway.oss.ari4java.generated." + apiVersion, thisClass, sb.toString() );
 
     }
 

--- a/codegen/ch/loway/oss/ari4java/codegen/genJava/JavaInterface.java
+++ b/codegen/ch/loway/oss/ari4java/codegen/genJava/JavaInterface.java
@@ -2,7 +2,7 @@
 package ch.loway.oss.ari4java.codegen.genJava;
 
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -26,7 +26,7 @@ public class JavaInterface {
     public String className = "";
     public String since = "";
 
-    Map<String,String> definitions = new HashMap<String, String>();
+    Map<String,String> definitions = new LinkedHashMap<>();
 
     public void iKnow( String signature, String method, String comment, String sinceVersion ) {
 
@@ -45,7 +45,7 @@ public class JavaInterface {
         ji.pkgName = pkgName;
         ji.className = className;
         ji.since = since;
-        ji.definitions = new HashMap<String, String>(definitions);
+        ji.definitions = new LinkedHashMap<>(definitions);
         return ji;
     }
 

--- a/codegen/ch/loway/oss/ari4java/codegen/genJava/JavaPkgInfo.java
+++ b/codegen/ch/loway/oss/ari4java/codegen/genJava/JavaPkgInfo.java
@@ -1,7 +1,7 @@
 
 package ch.loway.oss.ari4java.codegen.genJava;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -14,7 +14,7 @@ public class JavaPkgInfo {
     public final static Map<String,String> TypeMap;
 
     static {
-        TypeMap = new HashMap<String, String>();
+        TypeMap = new LinkedHashMap<>();
 
         TypeMap.put( "string", "String" );
         TypeMap.put( "long", "long" );

--- a/codegen/ch/loway/oss/ari4java/codegen/models/ClassTranslator.java
+++ b/codegen/ch/loway/oss/ari4java/codegen/models/ClassTranslator.java
@@ -4,7 +4,7 @@ import ch.loway.oss.ari4java.codegen.genJava.JavaGen;
 import ch.loway.oss.ari4java.codegen.genJava.JavaPkgInfo;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -20,7 +20,7 @@ public class ClassTranslator extends JavaPkgInfo {
     
     public ClassTranslator() {
         super();
-        mInterfaces = new HashMap<String,String>();
+        mInterfaces = new LinkedHashMap<>();
         imports = new ArrayList<String>();
         className = "ClassTranslator";
         imports.add("ch.loway.oss.ari4java.ARI" );


### PR DESCRIPTION
Without this fix, methods in the generated code will jump around when changing codegen-data which results in an unreadable diff to the previous version.