### PR TITLE
Fixed reconnectCount

### DIFF
--- a/classes/ch/loway/oss/ari4java/tools/WsClientAutoReconnect.java
+++ b/classes/ch/loway/oss/ari4java/tools/WsClientAutoReconnect.java
@@ -7,5 +7,5 @@ package ch.loway.oss.ari4java.tools;
  *
  */
 public interface WsClientAutoReconnect {
-	void reconnectWs();
+	void reconnectWs(Throwable cause);
 }

--- a/classes/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
+++ b/classes/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
@@ -412,6 +412,7 @@ public class NettyHttpClient implements HttpClient, WsClient, WsClientAutoReconn
         if (!group.isShuttingDown()) {
             // schedule reconnect after a 2,5,10 seconds
             long[] timeouts = {2L, 5L, 10L};
+            long timeout = reconnectCount >= timeouts.length ? timeouts[timeouts.length - 1] : timeouts[reconnectCount];
             reconnectCount++;
             shutDownGroup.schedule(new Runnable() {
                 @Override
@@ -426,7 +427,7 @@ public class NettyHttpClient implements HttpClient, WsClient, WsClientAutoReconn
                         wsCallback.onFailure(e);
                     }
                 }
-            }, reconnectCount >= timeouts.length ? timeouts[timeouts.length - 1] : timeouts[reconnectCount], TimeUnit.SECONDS);
+            }, timeout, TimeUnit.SECONDS);
         }
     }
 }

--- a/classes/ch/loway/oss/ari4java/tools/http/NettyWSClientHandler.java
+++ b/classes/ch/loway/oss/ari4java/tools/http/NettyWSClientHandler.java
@@ -55,7 +55,7 @@ public class NettyWSClientHandler extends NettyHttpClientHandler {
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         if (!shuttingDown) {
             if (this.wsClient != null) {
-                wsClient.reconnectWs();
+                wsClient.reconnectWs(null);
             } else {
                 wsCallback.onDisconnect();
             }
@@ -91,7 +91,7 @@ public class NettyWSClientHandler extends NettyHttpClientHandler {
             ch.close();
             if (!shuttingDown) {
                 if (this.wsClient != null) {
-                    wsClient.reconnectWs();
+                    wsClient.reconnectWs(null);
                 } else {
                     wsCallback.onDisconnect();
                 }

--- a/classes/ch/loway/oss/ari4java/tools/http/NettyWSClientHandler.java
+++ b/classes/ch/loway/oss/ari4java/tools/http/NettyWSClientHandler.java
@@ -69,7 +69,6 @@ public class NettyWSClientHandler extends NettyHttpClientHandler {
         if (!handshaker.isHandshakeComplete()) {
             handshaker.finishHandshake(ch, (FullHttpResponse) msg);
             handshakeFuture.setSuccess();
-            wsCallback.onChReadyToWrite();
             return;
         }
         


### PR DESCRIPTION
Three fixes:

d4cf992:
A Websocket is only connected successfully if HTTP __and__ Websocket handshake were successful.
Notice that also `onChReadyToWrite()` will be called __after__ handshaking instead of before.
This fixes the problem that `reconnectCount` is reset even if the handshake was not successful!

69d4d8d:
Check `reconnectCount` for each call of `reconnectWs(..)`.
Therefore, we have to pass an (nullable) `Throwable cause` to implement old behavior.
This fixes the problem that reconnects via `channelInactive(..)` did reconnect in an infinite loop (ignoring the limit of 10)!

09b9563:
Compute reconnect timeout before incrementing the counter.
This fixes the problem, that `timeouts[0]` was never used!