### PR TITLE
Get-Parameters must be URL-encoded

### DIFF
--- a/classes/ch/loway/oss/ari4java/tools/BaseAriAction.java
+++ b/classes/ch/loway/oss/ari4java/tools/BaseAriAction.java
@@ -6,6 +6,8 @@ import ch.loway.oss.ari4java.tools.WsClient.WsClientConnection;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,6 +49,14 @@ public class BaseAriAction {
         lE = new ArrayList<HttpResponse>();
         url = null;
         wsUpgrade = false;
+    }
+
+    protected static String urlEncode(String s) {
+        try {
+            return URLEncoder.encode(s, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException(e); // cannot happen!
+        }
     }
 
     public synchronized void forceResponse(String r) {

--- a/codegen/ch/loway/oss/ari4java/codegen/models/Operation.java
+++ b/codegen/ch/loway/oss/ari4java/codegen/models/Operation.java
@@ -2,6 +2,8 @@
 package ch.loway.oss.ari4java.codegen.models;
 
 import ch.loway.oss.ari4java.codegen.genJava.JavaGen;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,7 +52,7 @@ public class Operation {
         String stUri = parent.path;
         for ( Param p: parms ) {
             if ( p.type == ParamType.PATH ) {
-                stUri = stUri.replace("{" + p.name + "}", "\" + " + p.name + " + \"" );
+                stUri = stUri.replace("{" + p.name + "}", "\" + urlEncode(" + p.name + ") + \"" );
             }
         }
         // 1. Private helper method


### PR DESCRIPTION
Eg.
The syntax of requesting a device state is `GET /deviceStates/{deviceName}`.
So for device `SIP/123`, you have to encode it to `SIP%2f123`.
Otherwise the server can't understand our request and responds with an error.

The same problem occurs with other GET parameters like bridge id, channel id, app name, etc ...

Btw: I did not update the generated code as the diff would be a mess.