### PR TITLE
Allow multiple instances of ActionEvents (fixes ConcurrentModificationException)

### DIFF
--- a/classes/ch/loway/oss/ari4java/ARI.java
+++ b/classes/ch/loway/oss/ari4java/ARI.java
@@ -31,6 +31,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URLConnection;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -51,6 +52,7 @@ public class ARI {
     private WsClient wsClient;
     private ActionEvents liveActionEvent = null;
     private AriSubscriber subscriptions = new AriSubscriber();
+    private final CopyOnWriteArrayList<BaseAriAction> liveActionList = new CopyOnWriteArrayList<>();
 
     public void setHttpClient(HttpClient httpClient) {
         this.httpClient = httpClient;
@@ -106,6 +108,7 @@ public class ARI {
         BaseAriAction action = (BaseAriAction) buildConcreteImplementation(klazz);
         action.setHttpClient(this.httpClient);
         action.setWsClient(this.wsClient);
+        action.setLiveActionList(this.liveActionList);
         return (T) action;
     }
     
@@ -366,13 +369,12 @@ public class ARI {
 
     public void cleanup() throws ARIException {
 
-        if ( liveActionEvent != null ) {
+        for (BaseAriAction liveAction : liveActionList) {
             try {
-                closeAction(liveActionEvent);
+                closeAction(liveAction);
             } catch (ARIException e) {
                 // ignore on cleanup...
             }
-            liveActionEvent = null;
         }
 
         destroy( wsClient );
@@ -500,8 +502,7 @@ public class ARI {
      * @return an Events object.
      */
     public ActionEvents events() {
-        if (liveActionEvent == null)
-            liveActionEvent = (ActionEvents) setupAction(version.builder().actionEvents());
+        liveActionEvent = (ActionEvents) setupAction(version.builder().actionEvents());
         return liveActionEvent;
     }
 
@@ -553,6 +554,7 @@ public class ARI {
             BaseAriAction action = (BaseAriAction) a;
             action.setHttpClient(this.httpClient);
             action.setWsClient(this.wsClient);
+            action.setLiveActionList(this.liveActionList);
         } else {
             throw new IllegalArgumentException("Object does not seem to be an Action implementation " + a.toString());
         }

--- a/classes/ch/loway/oss/ari4java/tools/BaseAriAction.java
+++ b/classes/ch/loway/oss/ari4java/tools/BaseAriAction.java
@@ -36,6 +36,7 @@ public class BaseAriAction {
     protected String method;
     protected boolean wsUpgrade = false;
     protected WsClientConnection wsConnection;
+    private List<BaseAriAction> liveActionList;
 
     /**
      * Reset contents in preparation for new RPC
@@ -91,6 +92,7 @@ public class BaseAriAction {
             }
             try {
                 wsConnection = wsClient.connect(asyncHandler, this.url, this.lParamQuery);
+                liveActionList.add(this);
             } catch (RestException e) {
                 asyncHandler.getCallback().onFailure(e);
             }
@@ -203,6 +205,7 @@ public class BaseAriAction {
      */
     public synchronized void disconnectWs() throws RestException {
         if (wsConnection != null) {
+            liveActionList.remove(this);
             wsConnection.disconnect();
         }
         wsConnection = null;
@@ -214,6 +217,10 @@ public class BaseAriAction {
 
     public synchronized void setWsClient(WsClient wsClient) {
         this.wsClient = wsClient;
+    }
+
+    public synchronized void setLiveActionList(List<BaseAriAction> liveActionList) {
+        this.liveActionList = liveActionList;
     }
 }
 


### PR DESCRIPTION
Up to this fix, `ARI.events()` is always returning the same instance.

This is a very bad idea when calling `ARI.events().userEvent(..)` concurrently, because they work on the very same instance of `BaseAriAction` and concurrently modify `lParamQuery`, `lParamForm`, `lParamBody`, etc.

This results in a `ConcurrentModificationException` in the good case, or in sending complete nonsense to the Asterisk server in the bad case!

---

My fix is to not reuse the previous instances of `ActionEvents`. This involves a bit more effort to keep track of open WebSocket connection. This is done by the (thread-safe) list `liveActionList`, which is handed down to the `BaseAriAction`. There, each new WebSocket connection will be added to the list (and removed when it gets disconnected).
