### PR TITLE
Increased Websocket frame size from 256 kb to 16 Mb

### DIFF
--- a/classes/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
+++ b/classes/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class NettyHttpClient implements HttpClient, WsClient, WsClientAutoReconnect {
 
-    public static final int MAX_HTTP_REQUEST_KB = 256;
+    public static final int MAX_HTTP_REQUEST_KB = 16 * 1024;
     
     private Bootstrap bootStrap;
     private URI baseUri;


### PR DESCRIPTION
Frame size ist way too small to handle large responses (e.g. lists of peer / device)