### PR TITLE
New supported getWebsocketQueue() method for Asterisk 13.19+

### DIFF
--- a/classes/ch/loway/oss/ari4java/ARI.java
+++ b/classes/ch/loway/oss/ari4java/ARI.java
@@ -440,6 +440,48 @@ public class ARI {
 
     }
 
+    /**
+     * In order to avoid multi-threading for users, you can get a
+     * MessageQueue object and poll on it for new messages.
+     * This makes sure you don't really need to synchonize or be worried by
+     * threading issues
+     *
+     * For Asterisk 13.19+, the eventWebsocket call with only the app name and callback is no more supported.
+     *
+     * This method will add the subscribeAll parameter in the underlying eventWebsocket call which is supported by
+     * later asterisk version.
+     *
+     * You can also pass the wanted app (hint: use "dialer" for all messages)
+     *
+     * @return The MQ connected to your websocket.
+     * @throws ARIException
+     */
+
+
+    public MessageQueue getWebsocketQueue(String app) throws ARIException {
+
+        if ( liveActionEvent != null ) {
+            throw new ARIException( "Websocket already present" );
+        }
+
+        final MessageQueue q = new MessageQueue();
+
+        events().eventWebsocket( app, true, new AriCallback<Message>() {
+
+            @Override
+            public void onSuccess(Message result) {
+                q.queue( result );
+            }
+
+            @Override
+            public void onFailure(RestException e) {
+                q.queueError("Err:" + e.getMessage());
+            }
+        });
+
+        return q;
+
+    }
 
 
     /**


### PR DESCRIPTION
For Asterisk 13.19+, the `eventWebsocket` call with only the app name and callback is no more supported so the `getWebsocketQueue()` call will fail with an unsupported exception.

A new method `getWebsocketQueue(String)` is added which will call the supported underlying `eventWebsocket` method with the subscribeAll parameter set so the call will no more fail