### PR TITLE
fixed unknown tag error in javadoc

### DIFF
--- a/classes/ch/loway/oss/ari4java/tools/BaseAriAction.java
+++ b/classes/ch/loway/oss/ari4java/tools/BaseAriAction.java
@@ -165,7 +165,7 @@ public class BaseAriAction {
      * @param <A> The abstract type for members of the list.
      * @param <C> The concrete type for members of the list.
      * @param json Data in
-     * @param refConcreteType The reference concrete type, should be a List<C>
+     * @param refConcreteType The reference concrete type, should be a List&lt;C&gt;
      * @return a list of A's
      * @throws RestException
      */


### PR DESCRIPTION
Currently the project does not build (noticed while trying to get a more current version via https://jitpack.io/#l3nz/ari4java) due to the javadoc step producing an "unknown tag error".
This was fixed by using HTML entities.