### PR TITLE
Interface inheritence

### DIFF
--- a/codegen/ch/loway/oss/ari4java/codegen/DefMapper.java
+++ b/codegen/ch/loway/oss/ari4java/codegen/DefMapper.java
@@ -111,6 +111,7 @@ public class DefMapper {
                 j = new JavaInterface();
                 j.pkgName = "ch.loway.oss.ari4java.generated";
                 j.className = m.getInterfaceName();
+                j.parent = m.extendsModel;
                 interfaces.put(m.getInterfaceName(), j);
             }
 

--- a/codegen/ch/loway/oss/ari4java/codegen/genJava/JavaInterface.java
+++ b/codegen/ch/loway/oss/ari4java/codegen/genJava/JavaInterface.java
@@ -25,6 +25,7 @@ public class JavaInterface {
     public String pkgName = "";
     public String className = "";
     public String since = "";
+    public String parent = "";
 
     Map<String,String> definitions = new HashMap<String, String>();
 
@@ -80,6 +81,8 @@ public class JavaInterface {
         
         if ( eventSources.contains( className )) {
             sb.append( " extends EventSource " );
+        } else if (!parent.isEmpty()) {
+            sb.append( " extends " + parent + " " );
         }
         
         

--- a/codegen/ch/loway/oss/ari4java/codegen/run.java
+++ b/codegen/ch/loway/oss/ari4java/codegen/run.java
@@ -14,7 +14,7 @@ public class run {
 
     //public static String SOURCES = "codegen-data/";
     
-    public static String PROJECT = "/Users/lenz/Desktop/ari4java";
+    public static String PROJECT = ".";
     
     public static String SOURCES = PROJECT + "/codegen-data/";
     


### PR DESCRIPTION
Fix issue #106 - `Model` already know about Swagger's "sub-types", just use this knowledge to add `extends <parent>` to interfaces.

This PR also includes the "fix" to not hardcode Lenz's desktop path, so I can test the code generator.