### PR TITLE
Java 9 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ build.xml
 # macbook
 .DS_Store
 
+/bin/
+/build/

--- a/build.gradle
+++ b/build.gradle
@@ -105,9 +105,9 @@ dependencies {
 	compile 'com.fasterxml.jackson.core:jackson-databind:2.2.2'
 	compile 'com.fasterxml.jackson.core:jackson-annotations:2.2.2'
 	compile 'io.netty:netty-all:4.0.25.Final'
+	compile 'javax.xml.bind:jaxb-api:2.1'
 
 	testCompile 'junit:junit:4.10'
-
 }
 
 task setVersionInSources() {

--- a/codegen/ch/loway/oss/ari4java/codegen/DefMapper.java
+++ b/codegen/ch/loway/oss/ari4java/codegen/DefMapper.java
@@ -554,6 +554,7 @@ public class DefMapper {
                 Arrays.asList( new String[] {
                     "ch.loway.oss.ari4java.generated." + apiVersion + ".models.*" ,
                     "ch.loway.oss.ari4java.generated." + apiVersion + ".actions.*",
+                    "ch.loway.oss.ari4java.generated.Module",
                     "ch.loway.oss.ari4java.generated.*",
                     "ch.loway.oss.ari4java.ARI"
         }));

--- a/codegen/ch/loway/oss/ari4java/codegen/genJava/JavaInterface.java
+++ b/codegen/ch/loway/oss/ari4java/codegen/genJava/JavaInterface.java
@@ -65,7 +65,8 @@ public class JavaInterface {
             "java.util.ArrayList",
             "ch.loway.oss.ari4java.tools.RestException",
             "ch.loway.oss.ari4java.tools.AriCallback",
-            "ch.loway.oss.ari4java.tools.tags.*"
+            "ch.loway.oss.ari4java.tools.tags.*",
+            "ch.loway.oss.ari4java.generated.Module"
         }));
 
         

--- a/codegen/ch/loway/oss/ari4java/codegen/models/Apis.java
+++ b/codegen/ch/loway/oss/ari4java/codegen/models/Apis.java
@@ -25,6 +25,7 @@ public class Apis extends JavaPkgInfo {
         JavaInterface ji = getBaseInterface();
 
         JavaGen.importClasses(sb, getActionsPackage(), Arrays.asList( new String[] {
+            "ch.loway.oss.ari4java.generated.Module",
             "ch.loway.oss.ari4java.generated.*",
             "java.util.Date",
             "java.util.List",

--- a/codegen/ch/loway/oss/ari4java/codegen/models/ClassTranslator.java
+++ b/codegen/ch/loway/oss/ari4java/codegen/models/ClassTranslator.java
@@ -24,6 +24,7 @@ public class ClassTranslator extends JavaPkgInfo {
         imports = new ArrayList<String>();
         className = "ClassTranslator";
         imports.add("ch.loway.oss.ari4java.ARI" );
+        imports.add("ch.loway.oss.ari4java.generated.Module");
         imports.add( "ch.loway.oss.ari4java.generated.*" );
     }
     

--- a/codegen/ch/loway/oss/ari4java/codegen/models/Model.java
+++ b/codegen/ch/loway/oss/ari4java/codegen/models/Model.java
@@ -33,6 +33,7 @@ public class Model extends JavaPkgInfo {
         imports.add( "java.util.Date" );
         imports.add( "java.util.List" );
         imports.add( "java.util.Map" );      
+        imports.add( "ch.loway.oss.ari4java.generated.Module");
         imports.add( "ch.loway.oss.ari4java.generated.*");
         imports.add( "com.fasterxml.jackson.databind.annotation.JsonDeserialize" );
     }

--- a/codegen/ch/loway/oss/ari4java/codegen/run.java
+++ b/codegen/ch/loway/oss/ari4java/codegen/run.java
@@ -14,7 +14,7 @@ public class run {
 
     //public static String SOURCES = "codegen-data/";
     
-    public static String PROJECT = "/Users/lenz/Desktop/ari4java";
+    public static String PROJECT = ".";
     
     public static String SOURCES = PROJECT + "/codegen-data/";
     


### PR DESCRIPTION
Fix issue #108 by adding an import for `ch.loway.oss.ari4java.generated.Module` in all relevant classes.

For Java 9 compatibility we also need to define an explicit dependency on JAXB which is no longer included in the core JDK.