### PR TITLE
Support Asterisk 13.24 / ARI 1.10.0

### DIFF
--- a/classes/ch/loway/oss/ari4java/AriVersion.java
+++ b/classes/ch/loway/oss/ari4java/AriVersion.java
@@ -12,7 +12,6 @@ import ch.loway.oss.ari4java.generated.ari_1_8_0.AriBuilder_impl_ari_1_8_0;
 import ch.loway.oss.ari4java.generated.ari_1_9_0.AriBuilder_impl_ari_1_9_0;
 import ch.loway.oss.ari4java.generated.ari_2_0_0.AriBuilder_impl_ari_2_0_0;
 import ch.loway.oss.ari4java.generated.ari_3_0_0.AriBuilder_impl_ari_3_0_0;
-
 import ch.loway.oss.ari4java.tools.ARIException;
 
 /**
@@ -37,7 +36,7 @@ public enum AriVersion {
     ARI_1_8_0 ( "1.8.0", new AriBuilder_impl_ari_1_8_0() ),
     /** Asterisk 13.7.0 */
     ARI_1_9_0 ( "1.9.0", new AriBuilder_impl_ari_1_9_0() ),
-    /** Asterisk 14.0.0 */
+    /** Asterisk 13.24.1 */
     ARI_1_10_0 ( "1.10.0", new AriBuilder_impl_ari_1_10_0() ),
     /** Asterisk 14.2.1 */
     ARI_2_0_0 ( "2.0.0", new AriBuilder_impl_ari_2_0_0() ),

--- a/codegen-data/ari_1_10_0/README.md
+++ b/codegen-data/ari_1_10_0/README.md
@@ -1,0 +1,1 @@
+Snapshot taken from Asterisk 13.24.1

--- a/codegen-data/ari_1_10_0/applications.json
+++ b/codegen-data/ari_1_10_0/applications.json
@@ -2,7 +2,7 @@
 	"_copyright": "Copyright (C) 2013, Digium, Inc.",
 	"_author": "David M. Lee, II <dlee@digium.com>",
 	"_svn_revision": "$Revision$",
-	"apiVersion": "1.7.0",
+	"apiVersion": "1.10.0",
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/applications.{format}",

--- a/codegen-data/ari_1_10_0/asterisk.json
+++ b/codegen-data/ari_1_10_0/asterisk.json
@@ -2,7 +2,7 @@
 	"_copyright": "Copyright (C) 2012 - 2013, Digium, Inc.",
 	"_author": "David M. Lee, II <dlee@digium.com>",
 	"_svn_revision": "$Revision$",
-	"apiVersion": "1.7.0",
+	"apiVersion": "1.10.0",
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/asterisk.{format}",

--- a/codegen-data/ari_1_10_0/bridges.json
+++ b/codegen-data/ari_1_10_0/bridges.json
@@ -2,7 +2,7 @@
 	"_copyright": "Copyright (C) 2012 - 2013, Digium, Inc.",
 	"_author": "David M. Lee, II <dlee@digium.com>",
 	"_svn_revision": "$Revision$",
-	"apiVersion": "1.7.0",
+	"apiVersion": "1.10.0",
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/bridges.{format}",
@@ -241,6 +241,78 @@
 			]
 		},
 		{
+			"path": "/bridges/{bridgeId}/videoSource/{channelId}",
+			"description": "Set a channel as the video source in a multi-party bridge",
+			"operations": [
+				{
+					"httpMethod": "POST",
+					"summary": "Set a channel as the video source in a multi-party mixing bridge. This operation has no effect on bridges with two or fewer participants.",
+					"nickname": "setVideoSource",
+					"responseClass": "void",
+					"parameters": [
+						{
+							"name": "bridgeId",
+							"description": "Bridge's id",
+							"paramType": "path",
+							"required": true,
+							"allowMultiple": false,
+							"dataType": "string"
+						},
+						{
+							"name": "channelId",
+							"description": "Channel's id",
+							"paramType": "path",
+							"required": true,
+							"allowMultiple": false,
+							"dataType": "string"
+						}
+					],
+					"errorResponses": [
+						{
+							"code": 404,
+							"reason": "Bridge or Channel not found"
+						},
+						{
+							"code": 409,
+							"reason": "Channel not in Stasis application"
+						},
+						{
+							"code": 422,
+							"reason": "Channel not in this Bridge"
+						}
+					]
+				}
+			]
+		},
+		{
+			"path": "/bridges/{bridgeId}/videoSource",
+			"description": "Removes any explicit video source",
+			"operations": [
+				{
+					"httpMethod": "DELETE",
+					"summary": "Removes any explicit video source in a multi-party mixing bridge. This operation has no effect on bridges with two or fewer participants. When no explicit video source is set, talk detection will be used to determine the active video stream.",
+					"nickname": "clearVideoSource",
+					"responseClass": "void",
+					"parameters": [
+						{
+							"name": "bridgeId",
+							"description": "Bridge's id",
+							"paramType": "path",
+							"required": true,
+							"allowMultiple": false,
+							"dataType": "string"
+						}
+					],
+					"errorResponses": [
+						{
+							"code": 404,
+							"reason": "Bridge not found"
+						}
+					]
+				}
+			]
+		},
+		{
 			"path": "/bridges/{bridgeId}/moh",
 			"description": "Play music on hold to a bridge",
 			"operations": [
@@ -328,10 +400,10 @@
 						},
 						{
 							"name": "media",
-							"description": "Media URIs to play.",
+							"description": "Media's URI to play.",
 							"paramType": "query",
 							"required": true,
-							"allowMultiple": true,
+							"allowMultiple": false,
 							"dataType": "string"
 						},
 						{
@@ -344,7 +416,7 @@
 						},
 						{
 							"name": "offsetms",
-							"description": "Number of milliseconds to skip before playing. Only applies to the first URI if multiple media URIs are specified.",
+							"description": "Number of media to skip before playing.",
 							"paramType": "query",
 							"required": false,
 							"allowMultiple": false,
@@ -420,10 +492,10 @@
 						},
 						{
 							"name": "media",
-							"description": "Media URIs to play.",
+							"description": "Media's URI to play.",
 							"paramType": "query",
 							"required": true,
-							"allowMultiple": true,
+							"allowMultiple": false,
 							"dataType": "string"
 						},
 						{
@@ -436,7 +508,7 @@
 						},
 						{
 							"name": "offsetms",
-							"description": "Number of milliseconds to skip before playing. Only applies to the first URI if multiple media URIs are specified.",
+							"description": "Number of media to skip before playing.",
 							"paramType": "query",
 							"required": false,
 							"allowMultiple": false,
@@ -649,6 +721,16 @@
 					"type": "List[string]",
 					"description": "Ids of channels participating in this bridge",
 					"required": true
+				},
+				"video_mode": {
+					"type": "string",
+					"description": "The video mode the bridge is using. One of 'none', 'talker', or 'single'.",
+					"required": false
+				},
+				"video_source_id": {
+					"type": "string",
+					"description": "The ID of the channel that is the source of video in this bridge, if one exists.",
+					"required": false
 				}
 			}
 		}

--- a/codegen-data/ari_1_10_0/channels.json
+++ b/codegen-data/ari_1_10_0/channels.json
@@ -2,7 +2,7 @@
 	"_copyright": "Copyright (C) 2012 - 2013, Digium, Inc.",
 	"_author": "David M. Lee, II <dlee@digium.com>",
 	"_svn_revision": "$Revision$",
-	"apiVersion": "1.7.0",
+	"apiVersion": "1.10.0",
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/channels.{format}",
@@ -142,76 +142,10 @@
 						{
 							"code": 400,
 							"reason": "Invalid parameters for originating a channel."
-						}
-					]
-				}
-			]
-		},
-		{
-			"path": "/channels/create",
-			"description": "Create a channel and place it in a Stasis app, but do not dial the channel yet.",
-			"operations": [
-				{
-					"httpMethod": "POST",
-					"summary": "Create channel.",
-					"nickname": "create",
-					"responseClass": "Channel",
-					"parameters": [
-						{
-							"name": "endpoint",
-							"description": "Endpoint for channel communication",
-							"paramType": "query",
-							"required": true,
-							"allowMultiple": false,
-							"dataType": "string"
 						},
 						{
-							"name": "app",
-							"description": "Stasis Application to place channel into",
-							"paramType": "query",
-							"required": true,
-							"allowMultiple": false,
-							"dataType": "string"
-						},
-						{
-							"name": "appArgs",
-							"description": "The application arguments to pass to the Stasis application provided by 'app'. Mutually exclusive with 'context', 'extension', 'priority', and 'label'.",
-							"paramType": "query",
-							"required": false,
-							"allowMultiple": false,
-							"dataType": "string"
-						},
-						{
-							"name": "channelId",
-							"description": "The unique id to assign the channel on creation.",
-							"paramType": "query",
-							"required": false,
-							"allowMultiple": false,
-							"dataType": "string"
-						},
-						{
-							"name": "otherChannelId",
-							"description": "The unique id to assign the second channel when using local channels.",
-							"paramType": "query",
-							"required": false,
-							"allowMultiple": false,
-							"dataType": "string"
-						},
-						{
-							"name": "originator",
-							"description": "Unique ID of the calling channel",
-							"paramType": "query",
-							"required": false,
-							"allowMultiple": false,
-							"dataType": "string"
-						},
-						{
-							"name": "formats",
-							"description": "The format name capability list to use if originator is not specified. Ex. \"ulaw,slin16\".  Format names can be found with \"core show codecs\".",
-							"paramType": "query",
-							"required": false,
-							"allowMultiple": false,
-							"dataType": "string"
+							"code": 409,
+							"reason": "Channel with given unique ID already exists."
 						}
 					]
 				}
@@ -368,9 +302,12 @@
 						{
 							"code": 400,
 							"reason": "Invalid parameters for originating a channel."
+						},
+						{
+							"code": 409,
+							"reason": "Channel with given unique ID already exists."
 						}
 					]
-
 				},
 				{
 					"httpMethod": "DELETE",
@@ -477,10 +414,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				}
@@ -529,10 +462,6 @@
 						{
 							"code": 422,
 							"reason": "Endpoint is not the same type as the channel"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				}
@@ -565,10 +494,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				}
@@ -601,10 +526,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				},
@@ -631,10 +552,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				}
@@ -715,10 +632,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				}
@@ -768,10 +681,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				},
@@ -815,10 +724,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				}
@@ -851,10 +756,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				},
@@ -881,10 +782,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				}
@@ -926,10 +823,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				},
@@ -956,10 +849,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				}
@@ -993,10 +882,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				},
@@ -1023,10 +908,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				}
@@ -1053,10 +934,10 @@
 						},
 						{
 							"name": "media",
-							"description": "Media URIs to play.",
+							"description": "Media's URI to play.",
 							"paramType": "query",
 							"required": true,
-							"allowMultiple": true,
+							"allowMultiple": false,
 							"dataType": "string"
 						},
 						{
@@ -1069,7 +950,7 @@
 						},
 						{
 							"name": "offsetms",
-							"description": "Number of milliseconds to skip before playing. Only applies to the first URI if multiple media URIs are specified.",
+							"description": "Number of media to skip before playing.",
 							"paramType": "query",
 							"required": false,
 							"allowMultiple": false,
@@ -1101,10 +982,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				}
@@ -1139,10 +1016,10 @@
 						},
 						{
 							"name": "media",
-							"description": "Media URIs to play.",
+							"description": "Media's URI to play.",
 							"paramType": "query",
 							"required": true,
-							"allowMultiple": true,
+							"allowMultiple": false,
 							"dataType": "string"
 						},
 						{
@@ -1155,7 +1032,7 @@
 						},
 						{
 							"name": "offsetms",
-							"description": "Number of milliseconds to skip before playing. Only applies to the first URI if multiple media URIs are specified.",
+							"description": "Number of media to skip before playing.",
 							"paramType": "query",
 							"required": false,
 							"allowMultiple": false,
@@ -1179,10 +1056,6 @@
 						{
 							"code": 409,
 							"reason": "Channel not in a Stasis application"
-						},
-						{
-							"code": 412,
-							"reason": "Channel in invalid state"
 						}
 					]
 				}
@@ -1586,59 +1459,6 @@
 						{
 							"code": 404,
 							"reason": "Channel not found"
-						}
-					]
-				}
-			]
-		},
-		{
-			"path": "/channels/{channelId}/dial",
-			"description": "Dial a channel",
-			"operations": [
-				{
-					"httpMethod": "POST",
-					"summary": "Dial a created channel.",
-					"nickname": "dial",
-					"responseClass": "void",
-					"parameters": [
-						{
-							"name": "channelId",
-							"description": "Channel's id",
-							"paramType": "path",
-							"required": true,
-							"allowMultiple": false,
-							"dataType": "string"
-						},
-						{
-							"name": "caller",
-							"description": "Channel ID of caller",
-							"paramType": "query",
-							"required": false,
-							"allowMultiple": false,
-							"dataType": "string"
-						},
-						{
-							"name": "timeout",
-							"description": "Dial timeout",
-							"paramType": "query",
-							"required": false,
-							"allowMultiple": false,
-							"dataType": "int",
-							"defaultValue": 0,
-							"allowableValues": {
-								"valueType": "RANGE",
-								"min": 0
-							}
-						}
-					],
-					"errorResponses": [
-						{
-							"code": 404,
-							"reason": "Channel cannot be found."
-						},
-						{
-							"code": 409,
-							"reason": "Channel cannot be dialed."
 						}
 					]
 				}

--- a/codegen-data/ari_1_10_0/deviceStates.json
+++ b/codegen-data/ari_1_10_0/deviceStates.json
@@ -2,7 +2,7 @@
 	"_copyright": "Copyright (C) 2012 - 2013, Digium, Inc.",
 	"_author": "Kevin Harwell <kharwell@digium.com>",
 	"_svn_revision": "$Revision$",
-	"apiVersion": "1.7.0",
+	"apiVersion": "1.10.0",
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/deviceStates.{format}",

--- a/codegen-data/ari_1_10_0/endpoints.json
+++ b/codegen-data/ari_1_10_0/endpoints.json
@@ -2,7 +2,7 @@
 	"_copyright": "Copyright (C) 2012 - 2013, Digium, Inc.",
 	"_author": "David M. Lee, II <dlee@digium.com>",
 	"_svn_revision": "$Revision$",
-	"apiVersion": "1.7.0",
+	"apiVersion": "1.10.0",
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/endpoints.{format}",

--- a/codegen-data/ari_1_10_0/events.json
+++ b/codegen-data/ari_1_10_0/events.json
@@ -2,7 +2,7 @@
 	"_copyright": "Copyright (C) 2012 - 2013, Digium, Inc.",
 	"_author": "David M. Lee, II <dlee@digium.com>",
 	"_svn_revision": "$Revision$",
-	"apiVersion": "1.7.0",
+	"apiVersion": "1.10.0",
 	"swaggerVersion": "1.2",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/events.{format}",
@@ -110,6 +110,11 @@
 					"type": "string",
 					"required": true,
 					"description": "Indicates the type of this message."
+				},
+				"asterisk_id": {
+					"type": "string",
+					"required": false,
+					"description": "The unique ID for the Asterisk instance that raised this event."
 				}
 			},
 			"subTypes": [
@@ -146,7 +151,6 @@
 			"subTypes": [
 				"DeviceStateChanged",
 				"PlaybackStarted",
-				"PlaybackContinuing",
 				"PlaybackFinished",
 				"RecordingStarted",
 				"RecordingFinished",
@@ -157,6 +161,7 @@
 				"BridgeMerged",
 				"BridgeBlindTransfer",
 				"BridgeAttendedTransfer",
+				"BridgeVideoSourceChanged",
 				"ChannelCreated",
 				"ChannelDestroyed",
 				"ChannelEnteredBridge",
@@ -271,17 +276,6 @@
 				}
 			}
 		},
-		"PlaybackContinuing": {
-			"id": "PlaybackContinuing",
-			"description": "Event showing the continuation of a media playback operation from one media URI to the next in the list.",
-			"properties": {
-				"playback": {
-					"type": "Playback",
-					"description": "Playback control object",
-					"required": true
-				}
-			}
-		},
 		"PlaybackFinished": {
 			"id": "PlaybackFinished",
 			"description": "Event showing the completion of a media playback operation.",
@@ -362,6 +356,20 @@
 				"bridge_from": {
 					"required": true,
 					"type": "Bridge"
+				}
+			}
+		},
+		"BridgeVideoSourceChanged": {
+			"id": "BridgeVideoSourceChanged",
+			"description": "Notification that the source of video in a bridge has changed.",
+			"properties": {
+				"bridge": {
+					"required": true,
+					"type": "Bridge"
+				},
+				"old_video_source_id": {
+					"required": false,
+					"type": "string"
 				}
 			}
 		},

--- a/codegen-data/ari_1_10_0/mailboxes.json
+++ b/codegen-data/ari_1_10_0/mailboxes.json
@@ -2,7 +2,7 @@
 	"_copyright": "Copyright (C) 2013, Digium, Inc.",
 	"_author": "Jonathan Rose <jrose@digium.com>",
 	"_svn_revision": "$Revision$",
-	"apiVersion": "1.7.0",
+	"apiVersion": "1.10.0",
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/mailboxes.{format}",

--- a/codegen-data/ari_1_10_0/playbacks.json
+++ b/codegen-data/ari_1_10_0/playbacks.json
@@ -2,7 +2,7 @@
 	"_copyright": "Copyright (C) 2012 - 2013, Digium, Inc.",
 	"_author": "David M. Lee, II <dlee@digium.com>",
 	"_svn_revision": "$Revision$",
-	"apiVersion": "1.7.0",
+	"apiVersion": "1.10.0",
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/playbacks.{format}",
@@ -124,13 +124,8 @@
 				},
 				"media_uri": {
 					"type": "string",
-					"description": "The URI for the media currently being played back.",
+					"description": "URI for the media to play back.",
 					"required": true
-				},
-				"next_media_uri": {
-					"type": "string",
-					"description": "If a list of URIs is being played, the next media URI to be played back.",
-					"required": false
 				},
 				"target_uri": {
 					"type": "string",
@@ -150,8 +145,7 @@
 						"values": [
 							"queued",
 							"playing",
-							"continuing",
-							"done"
+							"complete"
 						]
 					}
 				}

--- a/codegen-data/ari_1_10_0/recordings.json
+++ b/codegen-data/ari_1_10_0/recordings.json
@@ -2,7 +2,7 @@
 	"_copyright": "Copyright (C) 2012 - 2013, Digium, Inc.",
 	"_author": "David M. Lee, II <dlee@digium.com>",
 	"_svn_revision": "$Revision$",
-	"apiVersion": "1.7.0",
+	"apiVersion": "1.10.0",
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/recordings.{format}",
@@ -61,38 +61,6 @@
 						}
 					],
 					"errorResponses": [
-						{
-							"code": 404,
-							"reason": "Recording not found"
-						}
-					]
-				}
-			]
-		},
-		{
-			"path": "/recordings/stored/{recordingName}/file",
-			"description": "The actual file associated with the stored recording",
-			"operations": [
-				{
-					"httpMethod": "GET",
-					"summary": "Get the file associated with the stored recording.",
-					"nickname": "getStoredFile",
-					"responseClass": "binary",
-					"parameters": [
-						{
-							"name": "recordingName",
-							"description": "The name of the recording",
-							"paramType": "path",
-							"required": true,
-							"allowMultiple": false,
-							"dataType": "string"
-						}
-					],
-					"errorResponses": [
-						{
-							"code": 403,
-							"reason": "The recording file could not be opened"
-						},
 						{
 							"code": 404,
 							"reason": "Recording not found"

--- a/codegen-data/ari_1_10_0/sounds.json
+++ b/codegen-data/ari_1_10_0/sounds.json
@@ -2,7 +2,7 @@
 	"_copyright": "Copyright (C) 2012 - 2013, Digium, Inc.",
 	"_author": "David M. Lee, II <dlee@digium.com>",
 	"_svn_revision": "$Revision$",
-	"apiVersion": "1.7.0",
+	"apiVersion": "1.10.0",
 	"swaggerVersion": "1.1",
 	"basePath": "http://localhost:8088/ari",
 	"resourcePath": "/api-docs/sounds.{format}",


### PR DESCRIPTION
I've included the REST-API of the current Asterisk version 13.24.1 to be used for code generation.

This replaces the previous ARI 1.10.0 which was based on Asterisk 14.0.0 (Beta?).
Apparently, Asterisk 14.2.1 and upwards are using ARI 2.0.0.
Further, Asterisk 13 has long term support and should be preferred over an early/beta Asterisk 14 definition.