### PR TITLE
unsubscribe may fail if the web socket is not connected

### DIFF
--- a/classes/ch/loway/oss/ari4java/ARI.java
+++ b/classes/ch/loway/oss/ari4java/ARI.java
@@ -368,7 +368,11 @@ public class ARI {
      */
 
     public void cleanup() throws ARIException {
-    	unsubscribeApplication();
+        try {
+    	    unsubscribeApplication();
+        } catch (ARIException e) {
+            // ignore on cleanup...
+        }
         for (BaseAriAction liveAction : liveActionList) {
             try {
                 closeAction(liveAction);


### PR DESCRIPTION
Then an `ARIException` is thrown and the cleanup is abandoned. We should ignore unsubscribe failures during cleanup