### PR TITLE
1  Changing JSON body shaping to fix object addition error

### DIFF
--- a/src/main/java/ch/loway/oss/ari4java/tools/HttpParam.java
+++ b/src/main/java/ch/loway/oss/ari4java/tools/HttpParam.java
@@ -22,6 +22,7 @@ public class HttpParam {
 
     public static List<ch.loway.oss.ari4java.tools.HttpParam> build(String key, Map<String,String> variables) {
         ArrayList<ch.loway.oss.ari4java.tools.HttpParam> vars = new ArrayList<>();
+        vars.add(build("key", key));
         if (variables != null) {
             for (Map.Entry<String, String> entry : variables.entrySet()) {
                 vars.add(build(entry.getKey(), entry.getValue()));

--- a/src/main/java/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
+++ b/src/main/java/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
@@ -27,6 +27,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -166,7 +167,7 @@ public class NettyHttpClient implements HttpClient, WsClient, WsClientAutoReconn
                 HttpVersion.HTTP_1_1, HttpMethod.valueOf(method), url);
         //System.out.println(request.getUri());
         if (parametersBody != null && !parametersBody.isEmpty()) {
-            String vars = makeBodyVariables(parametersBody);
+            String vars = makeJson(parametersBody);
             ByteBuf bbuf = Unpooled.copiedBuffer(vars, StandardCharsets.UTF_8);
 
             request.headers().add(HttpHeaders.Names.CONTENT_TYPE, "application/json");
@@ -178,26 +179,36 @@ public class NettyHttpClient implements HttpClient, WsClient, WsClientAutoReconn
         return request;
     }
     
+    private String makeJson(List<HttpParam> variables) {
+        String key = variables.remove(0).value;
+        return Objects.equals(key, "fields") ? makeBodyFields(variables) : makeBodyVariables(variables);
+    }
+    
     private String makeBodyVariables(List<HttpParam> variables) {
+        StringBuilder varBuilder = new StringBuilder();
+        varBuilder.append("{").append("\"variables\": {");
+        Iterator<HttpParam> entryIterator = variables.iterator();
+        while(entryIterator.hasNext()) {
+            HttpParam param = entryIterator.next();
+            varBuilder.append("\"").append(param.name).append("\"").append(": ").append("\"").append(param.value).append("\"");
+            if (entryIterator.hasNext()) {
+                varBuilder.append(",");
+            }
+        }
+        varBuilder.append("}}");
+        return varBuilder.toString();
+    }
+    
+    private String makeBodyFields(List<HttpParam> variables) {
         StringBuilder varBuilder = new StringBuilder();
         varBuilder.append("{").append("\"fields\": [");
         Iterator<HttpParam> entryIterator = variables.iterator();
         while (entryIterator.hasNext()) {
             HttpParam param = entryIterator.next();
-            varBuilder.append("{\"")
-                    .append("attribute")
-                    .append("\"")
-                    .append(": ")
-                    .append("\"")
-                    .append(param.name)
-                    .append("\",")
-                    .append("\"")
-                    .append("value")
-                    .append("\"")
-                    .append(": ")
-                    .append("\"")
-                    .append(param.value)
-                    .append("\"}");
+            varBuilder.append("{")
+                      .append("\"").append("attribute").append("\"").append(": ").append("\"").append(param.name).append("\",")
+                      .append("\"").append("value").append("\"").append(": ").append("\"").append(param.value).append("\"")
+                      .append("}");
             if (entryIterator.hasNext()) {
                 varBuilder.append(",");
             }

--- a/src/main/java/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
+++ b/src/main/java/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
@@ -177,20 +177,32 @@ public class NettyHttpClient implements HttpClient, WsClient, WsClientAutoReconn
         request.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE);
         return request;
     }
-
+    
     private String makeBodyVariables(List<HttpParam> variables) {
         StringBuilder varBuilder = new StringBuilder();
-        varBuilder.append("{").append("\"variables\": {");
+        varBuilder.append("{").append("\"fields\": [");
         Iterator<HttpParam> entryIterator = variables.iterator();
-        while(entryIterator.hasNext()) {
+        while (entryIterator.hasNext()) {
             HttpParam param = entryIterator.next();
-            varBuilder.append("\"").append(param.name).append("\"").append(": ").append("\"").append(param.value).append("\"");
+            varBuilder.append("{\"")
+                    .append("attribute")
+                    .append("\"")
+                    .append(": ")
+                    .append("\"")
+                    .append(param.name)
+                    .append("\",")
+                    .append("\"")
+                    .append("value")
+                    .append("\"")
+                    .append(": ")
+                    .append("\"")
+                    .append(param.value)
+                    .append("\"}");
             if (entryIterator.hasNext()) {
                 varBuilder.append(",");
             }
         }
-        varBuilder.append("}}");
-
+        varBuilder.append("]}");
         return varBuilder.toString();
     }
 


### PR DESCRIPTION
When adding an object to the asterisk (auth, aor, endpoint...) the passed parameters are ignored and the object with default asterisk parameters is written.