### PR TITLE
Don't send 0 for numeric parmeters that have not been specified

### DIFF
--- a/codegen/src/main/java/ch/loway/oss/ari4java/codegen/DefMapper.java
+++ b/codegen/src/main/java/ch/loway/oss/ari4java/codegen/DefMapper.java
@@ -433,6 +433,8 @@ public class DefMapper {
                     for (JsonNode parameter : parameters) {
                         Operation.Param p = new Operation.Param();
                         p.javaType = remapAbstractType(txt(parameter.get("dataType")));
+                        p.methodArgumentType = JavaPkgInfo.primitiveSignature.containsKey(p.javaType) ?
+                                JavaPkgInfo.primitiveSignature.get(p.javaType) : p.javaType;
                         p.name = txt(parameter.get("name"));
                         p.required = txt(parameter.get("required")).equalsIgnoreCase("true");
                         p.type = Operation.ParamType.build(txt(parameter.get("paramType")));

--- a/codegen/src/main/java/ch/loway/oss/ari4java/codegen/genJava/JavaPkgInfo.java
+++ b/codegen/src/main/java/ch/loway/oss/ari4java/codegen/genJava/JavaPkgInfo.java
@@ -10,20 +10,26 @@ import java.util.Map;
 public class JavaPkgInfo {
 
     public final static Map<String, String> TypeMap;
+    public final static Map<String, String> primitiveSignature;
 
     static {
         TypeMap = new HashMap<String, String>();
         TypeMap.put("string", "String");
-        TypeMap.put("long", "long");
-        TypeMap.put("int", "int");
-        TypeMap.put("double", "double");
+        TypeMap.put("long", "Long");
+        TypeMap.put("int", "Integer");
+        TypeMap.put("double", "Double");
         TypeMap.put("date", "Date");
         TypeMap.put("object", "Object");
-        TypeMap.put("boolean", "boolean");
+        TypeMap.put("boolean", "Boolean");
         TypeMap.put("binary", "byte[]");
         TypeMap.put("containers", "Map<String,String>");
+        
+        primitiveSignature = new HashMap<String, String>();
+        primitiveSignature.put("Boolean", "boolean");
+        primitiveSignature.put("Integer", "int");
+        primitiveSignature.put("Long", "long");
+        primitiveSignature.put("Double", "double");
     }
-
 
     String base = "ch.loway.oss.ari4java.generated";
     public String className = "";

--- a/codegen/src/main/java/ch/loway/oss/ari4java/codegen/models/Operation.java
+++ b/codegen/src/main/java/ch/loway/oss/ari4java/codegen/models/Operation.java
@@ -296,6 +296,7 @@ public class Operation {
         public String name = "";
         public ParamType type = ParamType.PATH;
         public String javaType = "";
+        public String methodArgumentType = "";
         public boolean required = true;
 
         public String getSignature(String returnType) {
@@ -308,7 +309,7 @@ public class Operation {
         public String getDefinition(String returnType) {
             StringBuilder sb = new StringBuilder();
             sb.append("  public ").append(returnType).append(" ").append(JavaGen.addPrefixAndCapitalize("set", name))
-                    .append("(").append(javaType).append(" ").append(name).append(")");
+                    .append("(").append(methodArgumentType).append(" ").append(name).append(")");
             return sb.toString();
         }
         

--- a/src/main/java/ch/loway/oss/ari4java/tools/HttpParam.java
+++ b/src/main/java/ch/loway/oss/ari4java/tools/HttpParam.java
@@ -31,15 +31,21 @@ public class HttpParam {
         return vars;
     }
 
-    public static HttpParam build(String n, int v) {
+    public static HttpParam build(String n, Integer v) {
+        if (null == v)
+            return build(n, (String)null);
         return build(n, Integer.toString(v));
     }
 
-    public static HttpParam build(String n, long v) {
+    public static HttpParam build(String n, Long v) {
+        if (null == v)
+            return build(n, (String)null);
         return build(n, Long.toString(v));
     }
 
-    public static HttpParam build(String n, boolean v) {
+    public static HttpParam build(String n, Boolean v) {
+        if (null == v)
+            return build(n, (String)null);
         return build(n, v ? "true" : "false");
     }
 


### PR DESCRIPTION
 (or `false` for boolean).

Parameters should be boxed (object type) in internal storage, so if the user did not specify the parameter, we will not assume the value is 0 - as in ARI not specifying an optional param often has more meaning than "zero". For example, in `POST /channels` ("channel originate"), not setting the priority means "1" and not "0".