### PR TITLE
make sure we don't cause RestException.getMessage() to return null

### DIFF
--- a/src/main/java/ch/loway/oss/ari4java/tools/RestException.java
+++ b/src/main/java/ch/loway/oss/ari4java/tools/RestException.java
@@ -39,6 +39,7 @@ public class RestException extends ARIException {
 
     public RestException(Throwable cause) {
         super(cause);
+        message = cause.getMessage();
     }
 
     public RestException(String s, Throwable cause) {

--- a/src/main/java/ch/loway/oss/ari4java/tools/RestException.java
+++ b/src/main/java/ch/loway/oss/ari4java/tools/RestException.java
@@ -31,7 +31,7 @@ public class RestException extends ARIException {
 
     public RestException(String s, String r, int code) {
         this(s, code);
-        String msg = extractError(r);
+        String msg = extractError(message = r);
         if (!msg.equals(r)) {
             message = msg;
         }


### PR DESCRIPTION
When using the `RestException(String,String,int)` constructor, the internal `message` variable used in the overridden `getMessage()` may not be set and left as `null`, causing callers to get unexpected `null`s from `getMessage()`.

I'm not saying that `getMessage()` should be `@NonNull` (though in my internal monologue, it is), but in this case, it doesn't seem to be purposeful.