### PR TITLE
reconnectCount should only be -1 when a shutdown is triggered. Otherw…

### DIFF
--- a/src/main/java/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
+++ b/src/main/java/ch/loway/oss/ari4java/tools/http/NettyHttpClient.java
@@ -502,16 +502,15 @@ public class NettyHttpClient implements HttpClient, WsClient, WsClientAutoReconn
 
                 @Override
                 public void disconnect() throws RestException {
-                    wsHandler.setShuttingDown(true);
                     Channel ch = wsChannelFuture.channel();
                     if (ch != null) {
                         // if connected send CloseWebSocketFrame as NettyWSClientHandler will close the connection when the server responds to it
-                        if (reconnectCount == 0) {
+                        // only when not shutdown yet, so we don't try to send another close frame
+                        if (!wsHandler.isShuttingDown()) {
                             logger.debug("Send CloseWebSocketFrame ...");
-                            // set to -1 so we don't try send another close frame
-                            reconnectCount = -1;
                             ch.writeAndFlush(new CloseWebSocketFrame());
                         }
+                        wsHandler.setShuttingDown(true);
                         // if the server is no longer there then close any way
                         ch.close();
                     }


### PR DESCRIPTION
…ise, in some seldom situations, an array index out of bounds exception can be thrown when trying to reconnect upon first connection (can happen when both java-app and asterisk is booting at same time)